### PR TITLE
Add a healthcheck route

### DIFF
--- a/src/main/java/io/siavashoutadi/jerseydemo/resources/ApiController.java
+++ b/src/main/java/io/siavashoutadi/jerseydemo/resources/ApiController.java
@@ -12,6 +12,14 @@ import javax.ws.rs.core.MediaType;
 
 @Path("/api/v1.0")
 public class ApiController {
+  @Path("/health")
+  @GET
+  @Produces(MediaType.TEXT_HTML)
+  public String getHealth() {
+    String hostname =  System.getenv("HOSTNAME");
+    return "Running OK on " + hostname;
+  }
+
   @Path("/products")
   @GET
   @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
To both check if the web server serving the routes
and also show the hostname we are running on. This
information can be used later to ensure load balacing
works.